### PR TITLE
Better docker

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
 
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: build-and-ci
+    #needs: build-and-ci
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
 
   build-and-push-image:
     runs-on: ubuntu-latest
-    #needs: build-and-ci
+    needs: build-and-ci
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN conda clean --all --yes
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/diffexpr"
 WORKDIR /opt/diffexpr
-#RUN pytest -vvv 
+RUN pytest -vvv 
 
 FROM diffexpr AS diffexpr_dev
 RUN mamba install jupyterlab matplotlib seaborn r-recommended r-irkernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM continuumio/miniconda3:latest AS base
 
-RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/" >  /etc/apt/sources.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
+RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/" >  /etc/apt/sources.list 
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
 
 RUN apt-get update \
     && apt-get install -y r-base libcurl4-openssl-dev libxml2-dev libssl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM continuumio/miniconda3:latest AS base
 
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/" >  /etc/apt/sources.list \
-    && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
 
 RUN apt-get update \
     && apt-get install -y r-base libcurl4-openssl-dev libxml2-dev libssl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
 FROM continuumio/miniconda3:latest AS base
 
+RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/" >  /etc/apt/sources.list
 RUN apt-get update \
     && apt-get install -y r-base libcurl4-openssl-dev libxml2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# R packages
 COPY setup.R /opt/setup.R
+RUN /usr/bin/Rscript /opt/setup.R
 
-RUN Rscript /opt/setup.R
-
+# python package (diffexpr)
 RUN conda config --add channels bioconda
 RUN conda config --add channels default
 RUN conda config --add channels anaconda
 RUN conda config --add channels conda-forge
-
 RUN conda config --set always_yes yes --set changeps1 no
 
 RUN conda install mamba

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN pytest -vvv
 
 FROM diffexpr AS diffexpr_dev
 RUN pip install jupyterlab matplotlib seaborn
-RUN /usr/bin/Rscript -e "install.packages('IRkernel')"
+RUN /usr/bin/Rscript -e "install.packages('IRkernel'); IRkernel::installspec(user = FALSE)"
 WORKDIR /opt/diffexpr
 RUN pytest -vvv 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:latest AS base
+FROM python:3.9.16-bullseye AS base
 
 
 RUN apt-get update \
@@ -7,17 +7,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 
-# python package (diffexpr)
-RUN conda config --add channels bioconda
-RUN conda config --add channels default
-RUN conda config --add channels anaconda
-RUN conda config --add channels conda-forge
-RUN conda config --set always_yes yes --set changeps1 no
-
-RUN conda install mamba
-RUN mamba install pandas tzlocal \
-    biopython ReportLab pytest
-RUN pip install rpy2
+RUN pip install pandas tzlocal \
+    biopython ReportLab pytest rpy2
 
 # R packages
 COPY setup.R /opt/setup.R
@@ -28,14 +19,13 @@ FROM base AS diffexpr
 COPY . /opt/diffexpr
 
 RUN python /opt/diffexpr/setup.py install
-RUN conda clean --all --yes
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/diffexpr"
 WORKDIR /opt/diffexpr
 RUN pytest -vvv 
 
 FROM diffexpr AS diffexpr_dev
-RUN mamba install jupyterlab matplotlib seaborn
+RUN pip install jupyterlab matplotlib seaborn
 RUN conda clean --all --yes
 RUN /usr/bin/Rscript -e "install.packages('IRkernel')"
 WORKDIR /opt/diffexpr

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # R packages
-COPY setup.R /opt/setup.R
-RUN /usr/bin/Rscript /opt/setup.R
+#COPY setup.R /opt/setup.R
+#RUN /usr/bin/Rscript /opt/setup.R
 
 # python package (diffexpr)
 RUN conda config --add channels bioconda
@@ -19,7 +19,7 @@ RUN conda config --set always_yes yes --set changeps1 no
 
 RUN conda install mamba
 RUN mamba install pandas tzlocal \
-  rpy2 biopython ReportLab 
+  rpy2 biopython ReportLab pytest
 
 FROM base AS diffexpr
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ WORKDIR /opt/diffexpr
 RUN pytest -vvv 
 
 FROM diffexpr AS diffexpr_dev
-RUN mamba install jupyterlab matplotlib seaborn r-recommended r-irkernel
+RUN mamba install jupyterlab matplotlib seaborn
 RUN conda clean --all --yes
+RUN RScript.exe  -e "install.packages('IRkernel')"
+WORKDIR /opt/diffexpr
+RUN pytest -vvv 
+
 CMD ["jupyter-lab", "--allow-root", "--ip", "0.0.0.0", "--port", "1234"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pytest -vvv
 FROM diffexpr AS diffexpr_dev
 RUN mamba install jupyterlab matplotlib seaborn
 RUN conda clean --all --yes
-RUN /use/bin/RScript -e "install.packages('IRkernel')"
+RUN /usr/bin/RScript -e "install.packages('IRkernel')"
 WORKDIR /opt/diffexpr
 RUN pytest -vvv 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN conda clean --all --yes
 
 ENV PYTHONPATH "${PYTHONPATH}:/opt/diffexpr"
 WORKDIR /opt/diffexpr
-RUN pytest -vvv
+#RUN pytest -vvv 
 
 FROM diffexpr AS diffexpr_dev
 RUN mamba install jupyterlab matplotlib seaborn r-recommended r-irkernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pytest -vvv
 FROM diffexpr AS diffexpr_dev
 RUN mamba install jupyterlab matplotlib seaborn
 RUN conda clean --all --yes
-RUN /usr/bin/RScript -e "install.packages('IRkernel')"
+RUN /usr/bin/Rscript -e "install.packages('IRkernel')"
 WORKDIR /opt/diffexpr
 RUN pytest -vvv 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN pytest -vvv
 
 FROM diffexpr AS diffexpr_dev
 RUN pip install jupyterlab matplotlib seaborn
-RUN conda clean --all --yes
 RUN /usr/bin/Rscript -e "install.packages('IRkernel')"
 WORKDIR /opt/diffexpr
 RUN pytest -vvv 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# R packages
-COPY setup.R /opt/setup.R
-RUN /usr/bin/Rscript /opt/setup.R
 
 # python package (diffexpr)
 RUN conda config --add channels bioconda
@@ -20,6 +17,10 @@ RUN conda config --set always_yes yes --set changeps1 no
 RUN conda install mamba
 RUN mamba install pandas tzlocal \
   rpy2 biopython ReportLab pytest
+
+# R packages
+COPY setup.R /opt/setup.R
+RUN /usr/bin/Rscript /opt/setup.R
 
 FROM base AS diffexpr
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pytest -vvv
 FROM diffexpr AS diffexpr_dev
 RUN mamba install jupyterlab matplotlib seaborn
 RUN conda clean --all --yes
-RUN RScript -e "install.packages('IRkernel')"
+RUN /use/bin/RScript -e "install.packages('IRkernel')"
 WORKDIR /opt/diffexpr
 RUN pytest -vvv 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM continuumio/miniconda3:latest AS base
 
 RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/" >  /etc/apt/sources.list
 RUN apt-get update \
-    && apt-get install -y r-base libcurl4-openssl-dev libxml2-dev \
+    && apt-get install -y r-base libcurl4-openssl-dev libxml2-dev libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM continuumio/miniconda3:latest AS base
 
-RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/" >  /etc/apt/sources.list
+RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/" >  /etc/apt/sources.list \
+    && sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
+
 RUN apt-get update \
     && apt-get install -y r-base libcurl4-openssl-dev libxml2-dev libssl-dev \
     && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # R packages
-#COPY setup.R /opt/setup.R
-#RUN /usr/bin/Rscript /opt/setup.R
+COPY setup.R /opt/setup.R
+RUN /usr/bin/Rscript /opt/setup.R
 
 # python package (diffexpr)
 RUN conda config --add channels bioconda

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM continuumio/miniconda3:latest AS base
 
-RUN echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran40/" >  /etc/apt/sources.list 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
 
 RUN apt-get update \
-    && apt-get install -y r-base libcurl4-openssl-dev libxml2-dev libssl-dev \
+    && apt-get install -y r-base r-base-dev libcurl4-openssl-dev libxml2-dev libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM continuumio/miniconda3:latest AS base
 
 
 RUN apt-get update \
-    && apt-get install -y r-base r-base-dev libcurl4-openssl-dev libxml2-dev libssl-dev \
+    && apt-get install -y r-base r-base-dev r-bioc-deseq2 libcurl4-openssl-dev libxml2-dev libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pytest -vvv
 FROM diffexpr AS diffexpr_dev
 RUN mamba install jupyterlab matplotlib seaborn
 RUN conda clean --all --yes
-RUN RScript.exe  -e "install.packages('IRkernel')"
+RUN RScript -e "install.packages('IRkernel')"
 WORKDIR /opt/diffexpr
 RUN pytest -vvv 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN conda config --set always_yes yes --set changeps1 no
 
 RUN conda install mamba
 RUN mamba install pandas tzlocal \
-  rpy2 biopython ReportLab pytest
+    biopython ReportLab pytest
+RUN pip install rpy2
 
 # R packages
 COPY setup.R /opt/setup.R


### PR DESCRIPTION
it is possible to reduce the size of the docker image by removing the conda dependency:

```bash
$ dockersize() { docker manifest inspect -v "$1" | jq -c 'if type == "array" then .[] else . end' |  jq -r '[ ( .Descriptor.platform | [ .os, .architecture, .variant, ."os.version" ] | del(..|nulls) | join("/") ), ( [ .SchemaV2Manifest.layers[].size ] | add ) ] | join(" ")' | numfmt --to iec --format '%.2f' --field 2 | sort | column -t ; }

$ SHA=04ce635d45fab3818cc973f916a805b3d9c1a0fb
$ MASTER_SHA=5c94c710b692df1cea5e1cb7fe6267d873cbdd67 

# the new docker image
$ dockersize ghcr.io/wckdouglas/diffexpr/diffexpr-dev:${SHA}
linux/amd64  1.38G 

# the master branch docker image
$ dockersize ghcr.io/wckdouglas/diffexpr/diffexpr-dev:${MASTER_SHA}
linux/amd64  2.17G

# the new docker image
$ dockersize ghcr.io/wckdouglas/diffexpr/diffexpr:${SHA}
linux/amd64  1.26G

# the master branch docker image
$ dockersize ghcr.io/wckdouglas/diffexpr/diffexpr:${MASTER_SHA}
linux/amd64  1.34G
```