### PR TITLE
add rlog transform

### DIFF
--- a/diffexpr/py_deseq.py
+++ b/diffexpr/py_deseq.py
@@ -245,6 +245,9 @@ class py_DESeq2:
         deseq rlog
         see: https://rdrr.io/bioc/DESeq2/man/rlog.html
 
+        TODO: DESeq2 version of this function accepts two additional optional arguments 
+        'intercept' and 'betaPriorVar' that have not been explicitly ported here.
+
         essentially running R code:
 
         >>> rld = DESeq2::rlog(dds, blind=True, fitType="parametric")

--- a/test/test_deseq.py
+++ b/test/test_deseq.py
@@ -130,6 +130,16 @@ def test_vst(setup_deseq, blind, fit_type):
 
 
 @pytest.mark.parametrize(
+    "blind,fit_type",
+    [(True, "parametric"), (True, "local"), (True, "mean"), (False, "parametric"), (False, "local"), (False, "mean")],
+)
+def test_rlog(setup_deseq, blind, fit_type):
+    df, dds = setup_deseq
+    rlog = dds.rlog(blind=blind, fit_type=fit_type)
+    assert rlog.shape == df.shape
+
+
+@pytest.mark.parametrize(
     "case,r_table,py_table",
     [
         ("deseq", "R_deseq.tsv", "py_deseq.tsv"),


### PR DESCRIPTION
This PR adds the [rlog transformation](https://rdrr.io/bioc/DESeq2/man/rlog.html) from DESeq2. Note that the DESeq2 version of this function accepts two additional optional arguments 'intercept' and 'betaPriorVar' that have not been explicitly ported here.